### PR TITLE
fixing secret handling for auth-token-value

### DIFF
--- a/drivers/pinot/src/metabase/driver/pinot.clj
+++ b/drivers/pinot/src/metabase/driver/pinot.clj
@@ -17,12 +17,10 @@
    [cheshire.core :as json]
    [clj-http.client :as http]
    [metabase.driver :as driver]
-   [metabase.driver.common :as driver.common]
    [metabase.driver.pinot.client :as pinot.client]
    [metabase.driver.pinot.execute :as pinot.execute]
    [metabase.driver.pinot.query-processor :as pinot.qp]
    [metabase.driver.pinot.sync :as pinot.sync]
-   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]))
 
@@ -33,35 +31,6 @@
                               :set-timezone                   true
                               :temporal/requires-default-unit true}]
   (defmethod driver/database-supports? [:pinot feature] [_driver _feature _db] supported?))
-
-(defmethod driver/connection-properties :pinot
-  [_driver]
-  [{:name         "controller-endpoint"
-    :display-name (deferred-tru "Controller Endpoint")
-    :helper-text  (deferred-tru "The full URL of your Pinot Controller (e.g. http://localhost:9000)")
-    :placeholder  "http://localhost:9000"
-    :required     true}
-   {:name         "auth-enabled"
-    :display-name (deferred-tru "Authentication Enabled")
-    :type         :boolean
-    :default      false}
-   {:name         "auth-token-type"
-    :display-name (deferred-tru "Authentication Token Type")
-    :placeholder  "Basic"
-    :default      "Basic"}
-   {:name         "auth-token-value"
-    :display-name (deferred-tru "Authentication Token Value")
-    :type         :password
-    :placeholder  "••••••••"}
-   {:name         "database-name"
-    :display-name (deferred-tru "Database Name")
-    :placeholder  "pinot"}
-   {:name         "query-options"
-    :display-name (deferred-tru "Query Options")
-    :helper-text  (deferred-tru "Additional query options as key=value pairs separated by semicolons")
-    :placeholder  "timeoutMs=30000;maxServerResponseSizeBytes=1048576"
-    :type         :text}
-   driver.common/ssh-tunnel-preferences])
 
 (defmethod driver/can-connect? :pinot
   [_ details]

--- a/drivers/pinot/src/metabase/driver/pinot/client.clj
+++ b/drivers/pinot/src/metabase/driver/pinot/client.clj
@@ -17,8 +17,8 @@
    [clj-http.client :as http]
    [clojure.core.async :as a]
    [clojure.string :as str]
-
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.secrets.models.secret :as secret]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -142,7 +142,7 @@
                        :database-name (:database-name details)
                        :auth-enabled     (:auth-enabled details)
                        :auth-token-type  (:auth-token-type details)
-                       :auth-token-value (:auth-token-value details))]
+                       :auth-token-value (secret/value-as-string nil details "auth-token-value"))]
 
         ;; Log the query, details, and response
         (log/debugf "Pinot details: %s, Pinot query: %s, Parsed Pinot response: %s"
@@ -177,7 +177,7 @@
           :database-name (:database-name details)
           :auth-enabled  (:auth-enabled details)
           :auth-token-type  (:auth-token-type details)
-          :auth-token-value (:auth-token-value details))
+          :auth-token-value (secret/value-as-string nil details "auth-token-value"))
         (catch Exception cancel-e
           (log/warnf cancel-e "Failed to cancel Pinot query with queryId %s" query-id))))))
 


### PR DESCRIPTION
This pull request refactors the Pinot driver to enhance security by integrating secret management for sensitive authentication data and removes unused connection properties. The most significant changes include replacing direct access to authentication token values with secure secret management calls and cleaning up unused code related to connection properties.

### Security Enhancements:
* Updated all occurrences of `:auth-token-value` in `drivers/pinot/src/metabase/driver/pinot/client.clj` and `drivers/pinot/src/metabase/driver/pinot/sync.clj` to use `secret/value-as-string` for secure retrieval of authentication tokens. [[1]](diffhunk://#diff-b7d08fbed5f5d4cfefe822509998506bf41ed9f8a773ee4d10bfd4b61082315aL145-R145) [[2]](diffhunk://#diff-b7d08fbed5f5d4cfefe822509998506bf41ed9f8a773ee4d10bfd4b61082315aL180-R180) [[3]](diffhunk://#diff-43d483f1a5fd6d4d720ee4701b837c49aed73172ff0017f50c56ab127ac3547fL41-R41) [[4]](diffhunk://#diff-43d483f1a5fd6d4d720ee4701b837c49aed73172ff0017f50c56ab127ac3547fL71-R71) [[5]](diffhunk://#diff-43d483f1a5fd6d4d720ee4701b837c49aed73172ff0017f50c56ab127ac3547fL87-R87) [[6]](diffhunk://#diff-43d483f1a5fd6d4d720ee4701b837c49aed73172ff0017f50c56ab127ac3547fL96-R96)
* Added `metabase.secrets.models.secret` as a required namespace in the affected files to support the new secret management functionality. [[1]](diffhunk://#diff-b7d08fbed5f5d4cfefe822509998506bf41ed9f8a773ee4d10bfd4b61082315aL20-R21) [[2]](diffhunk://#diff-43d483f1a5fd6d4d720ee4701b837c49aed73172ff0017f50c56ab127ac3547fL17-R18)

### Code Cleanup:
* Removed the `driver/connection-properties` method for the Pinot driver, which defined connection properties such as `controller-endpoint` and `auth-token-value`. These properties are no longer required due to the refactoring.