### PR TITLE
Surface Pinot query errors in the Metabase UI

### DIFF
--- a/drivers/pinot/src/metabase/driver/pinot/execute.clj
+++ b/drivers/pinot/src/metabase/driver/pinot/execute.clj
@@ -150,13 +150,23 @@
                          (let [error-messages (mapv :message exceptions)
                                combined-message (str/join "; " error-messages)]
                            (log/errorf "Pinot query returned exceptions: %s" (u/pprint-to-str exceptions))
-                           ;; Throw exception with :db error type so Metabase UI displays it as a database error
-                           ;; This ensures users see Pinot's error messages in the Metabase interface
+                           ;; Tag as :invalid-query (a :client error → 4xx) rather than :db (a :server error → 5xx)
+                           ;; so Metabase classifies this as a user/client error. Without this, the frontend
+                           ;; shows a generic "We're experiencing server issues" banner. :status-code 400
+                           ;; makes the HTTP status explicit for Metabase's streaming-response middleware.
+                           ;; :is-curated true signals to the FE that Pinot's error message is safe to surface.
                            (throw (ex-info (tru "Pinot query error: {0}" combined-message)
-                                           {:type       qp.error-type/db
-                                            :query      query
-                                            :exceptions exceptions})))
+                                           {:type        qp.error-type/invalid-query
+                                            :status-code 400
+                                            :is-curated  true
+                                            :query       query
+                                            :exceptions  exceptions})))
                          response))
+                     ;; Pass our own ex-info through unchanged. Re-wrapping in the Throwable catch
+                     ;; below would strip :status-code/:is-curated from the outermost ex-data, which
+                     ;; is where catch-exceptions middleware and streaming-response middleware look.
+                     (catch clojure.lang.ExceptionInfo e
+                       (throw e))
                      (catch Throwable e
                        (log/errorf e "Error executing query: %s" (ex-message e))
                        (throw (ex-info (tru "Error executing query: {0}" (ex-message e))

--- a/drivers/pinot/test/metabase/driver/pinot/execute_test.clj
+++ b/drivers/pinot/test/metabase/driver/pinot/execute_test.clj
@@ -170,8 +170,35 @@
        (fn [_ _]))
       (is false "expected exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :db (get-in (ex-data e) [:type]))
-            "Pinot errors should have :type :db so Metabase UI shows them as database errors"))))))
+        (is (= :invalid-query (get-in (ex-data e) [:type]))
+            "Pinot errors should have :type :invalid-query (a :client error) so Metabase classifies them as 4xx user errors rather than 5xx server errors"))))))
+
+(deftest pinot-exceptions-propagate-with-client-error-metadata
+  (testing "When Pinot returns errors in the :exceptions array, the driver throws an ex-info
+            whose ex-data tells Metabase to render the message inline in the UI as a 4xx
+            client error (rather than a generic 5xx 'We're experiencing server issues' banner)."
+    (with-redefs [qp.store/metadata-provider (constantly {:details {}})
+                  lib.metadata/database (fn [provider] provider)]
+      (let [pinot-exception {:errorCode 150 :message "Some Pinot error"}]
+        (try
+          (execute/execute-reducible-query
+           (fn [_ _] {:exceptions [pinot-exception]})
+           {:native {:query {:sql "SELECT foo"}}}
+           (fn [_ _]))
+          (is false "expected exception")
+          (catch clojure.lang.ExceptionInfo e
+            (let [data (ex-data e)]
+              (is (= :invalid-query (:type data))
+                  ":client error in the qp.error-type hierarchy, not :db (a :server error)")
+              (is (= 400 (:status-code data))
+                  "explicit status-code so streaming-response/exception middleware returns 4xx, not 5xx")
+              (is (true? (:is-curated data))
+                  "signals to the FE that Pinot's error message is safe to render verbatim")
+              (is (re-find #"Some Pinot error" (ex-message e))
+                  "original Pinot message must reach the user, not be replaced by a generic wrapper")
+              (is (= [pinot-exception]
+                     (:exceptions data))
+                  "raw Pinot exception payload preserved in ex-data for introspection"))))))))
 
 (deftest reduce-results-empty-native-uses-projections
   (testing "When native query has no rows, column names come from schema projections (empty result handling)."


### PR DESCRIPTION
## Commit Summary

- Tag `:exceptions`-array errors as `qp.error-type/invalid-query` (a `:client` error → HTTP 4xx) instead of `qp.error-type/db` (a `:server` error → 5xx), so Metabase classifies them as user errors rather than server failures.
- Add `:status-code 400` so the streaming-response middleware sets HTTP 400 explicitly rather than defaulting to 500.
- Add `:is-curated true` to signal to the frontend that Pinot's error message is safe to render verbatim.
- Add a `clojure.lang.ExceptionInfo` catch arm that passes our own ex-info through unchanged so the outer Throwable catch doesn't strip the new metadata.

Result: Pinot's actual SQLParsingError message now appears inline in the SQL editor instead of a generic "We're experiencing server issues" banner.
See commit message for more details.

## Testing

- 243 unit tests pass locally (`clojure -M:test-runner --config-file tests.edn`).
- Added regression test `pinot-exceptions-propagate-with-client-error-metadata`
  asserting `:type`, `:status-code`, `:is-curated`, and the preserved Pinot
  error message.
- Verified end-to-end against our production Metabase deployment backed by a
  real Pinot cluster. Confirmed Pinot query errors now return HTTP 400 and
  render inline in the UI (example query - `select * from zones z limit 10`).

## Known simplification

All errors Pinot returns via `:exceptions` are now tagged
`qp.error-type/invalid-query`. This is correct for SQL parsing errors
(errorCode 150) and most user-facing failures, but Pinot also uses
`:exceptions` for transient/server-side conditions like broker timeouts (250)
and query execution errors (200). A more precise mapping from `errorCode` to
Metabase error-type would be a natural follow-up.

## Note on CI

`.github/workflows/ci.yml` skips the test/lint/build/security jobs for fork
PRs (line 15). I've run the equivalents locally; happy to share outputs.