### PR TITLE
Support Pinot temporal grouping in Metabase

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,37 @@ Example:
 timeoutMs=10000;useMultistageEngine=false
 ```
 
+## Temporal Grouping
+
+Metabase time-grain grouping works with Pinot date/time columns discovered from `dateTimeFieldSpecs`. In the query builder, select a date/time breakout and choose a grain such as day, week, month, quarter, or year. The driver translates that grouping to Pinot `DATETRUNC` SQL and uses the Metabase report timezone when one is configured.
+
+Example Pinot schema field:
+
+```json
+{
+  "dateTimeFieldSpecs": [
+    {
+      "name": "DaysSinceEpoch",
+      "dataType": "INT",
+      "format": "1:DAYS:EPOCH",
+      "granularity": "1:DAYS"
+    }
+  ]
+}
+```
+
+Example SQL shape generated for a daily breakout:
+
+```sql
+SELECT
+  DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS') AS "DaysSinceEpoch__day",
+  COUNT(*) AS "flights"
+FROM airlineStats
+GROUP BY DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS')
+ORDER BY DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS') ASC
+LIMIT 5
+```
+
 ## SSH Tunnel Support
 
 The driver supports SSH tunneling for secure connections to Pinot instances that are not directly accessible. Configure SSH tunnel settings in the Metabase database connection settings under the **SSH tunnel** section.

--- a/drivers/pinot/src/metabase/driver/pinot/query_processor.clj
+++ b/drivers/pinot/src/metabase/driver/pinot/query_processor.clj
@@ -55,6 +55,91 @@
   [_driver value]
   (str "'" value "'"))
 
+(def ^:private temporal-unit->pinot-unit
+  {:second  "second"
+   :minute  "minute"
+   :hour    "hour"
+   :day     "day"
+   :week    "week"
+   :month   "month"
+   :quarter "quarter"
+   :year    "year"})
+
+(defn- quote-identifier
+  [identifier]
+  (str "\"" (str/replace (str identifier) #"\"" "\"\"") "\""))
+
+(defn- sql-string
+  [value]
+  (str "'" (str/replace (str value) #"'" "''") "'"))
+
+(defn- field-metadata
+  [field-id]
+  (when (integer? field-id)
+    (lib.metadata/field (qp.store/metadata-provider) field-id)))
+
+(defn- resolve-field-name
+  [field-id options]
+  (cond
+    ;; Integer field IDs from Metabase's internal field references
+    (integer? field-id)
+    (let [resolved-name (:name (field-metadata field-id))]
+      (log/debugf "Resolved field ID %s to name: %s" field-id resolved-name)
+      resolved-name)
+
+    ;; String field IDs from dropdown variables from other questions
+    ;; This is crucial for making dropdown variables work correctly
+    (string? field-id)
+    (do
+      (log/debugf "Using field name directly: %s" field-id)
+      field-id)
+
+    ;; Field names from options map (fallback)
+    (map? options)
+    (let [resolved-name (:name options)]
+      (log/debugf "Resolved field from options: %s" resolved-name)
+      resolved-name)
+
+    ;; Fallback for unknown field types
+    :else
+    (let [resolved-name (str "unknown-field-" field-id)]
+      (log/debugf "Using fallback field name: %s" resolved-name)
+      resolved-name)))
+
+(defn- temporal-unit
+  [options]
+  (when-let [unit (:temporal-unit options)]
+    (when-not (= unit :default)
+      (temporal-unit->pinot-unit (keyword unit)))))
+
+(defn- pinot-time-unit-from-format
+  [format]
+  (when-let [[_ unit] (and (string? format)
+                           (re-find #"(?i)^\d+:([A-Z]+):EPOCH$" format))]
+    (u/upper-case-en unit)))
+
+(defn- pinot-input-time-unit
+  [field-info]
+  (or (pinot-time-unit-from-format (:format field-info))
+      (when (= "TIMESTAMP" (:database-type field-info))
+        "MILLISECONDS")
+      "MILLISECONDS"))
+
+(defn- temporal-expression
+  [field-name field-info unit]
+  (let [timezone (get-in *query* [:settings :timezone] "UTC")]
+    (str "DATETRUNC("
+         (sql-string unit) ", "
+         (quote-identifier field-name) ", "
+         (sql-string (pinot-input-time-unit field-info)) ", "
+         (sql-string timezone) ", "
+         (sql-string "MILLISECONDS")
+         ")")))
+
+(defn- temporal-alias
+  [field-name unit]
+  (str field-name "__" unit))
+
 (defn- resolve-field
   [field-clause]
   (log/debugf "resolve-field called with field-clause: %s (type: %s)" field-clause (type field-clause))
@@ -71,38 +156,27 @@
         ;; Handle regular field references
         :else
         (let [[_ field-id options] field-clause
-              field-name (cond
-                           ;; Integer field IDs from Metabase's internal field references
-                           (integer? field-id)
-                           (let [resolved-name (-> (qp.store/metadata-provider)
-                                                   (lib.metadata/field field-id)
-                                                   :name)]
-                             (log/debugf "Resolved field ID %s to name: %s" field-id resolved-name)
-                             resolved-name)
-
-                           ;; String field IDs from dropdown variables from other questions
-                           ;; This is crucial for making dropdown variables work correctly
-                           (string? field-id)
-                           (do
-                             (log/debugf "Using field name directly: %s" field-id)
-                             field-id)
-
-                           ;; Field names from options map (fallback)
-                           (map? options)
-                           (let [resolved-name (:name options)]
-                             (log/debugf "Resolved field from options: %s" resolved-name)
-                             resolved-name)
-
-                           ;; Fallback for unknown field types
-                           :else
-                           (let [resolved-name (str "unknown-field-" field-id)]
-                             (log/debugf "Using fallback field name: %s" resolved-name)
-                             resolved-name))]
-          (log/debugf "resolve-field result: %s" (str "\"" field-name "\""))
-          (str "\"" field-name "\""))))
+              field-info (field-metadata field-id)
+              field-name (resolve-field-name field-id options)
+              resolved-field (if-let [unit (temporal-unit options)]
+                               (temporal-expression field-name field-info unit)
+                               (quote-identifier field-name))]
+          (log/debugf "resolve-field result: %s" resolved-field)
+          resolved-field)))
     (do
       (log/errorf "Invalid field clause structure: %s" field-clause)
       (throw (ex-info "Invalid field clause structure" {:field-clause field-clause})))))
+
+(defn- resolve-select-field
+  [field-clause]
+  (let [field-expression (resolve-field field-clause)]
+    (if (and (sequential? field-clause)
+             (= :field (first field-clause))
+             (temporal-unit (nth field-clause 2 nil)))
+      (let [[_ field-id options] field-clause
+            field-name (resolve-field-name field-id options)]
+        (str field-expression " AS " (quote-identifier (temporal-alias field-name (temporal-unit options)))))
+      field-expression)))
 
 (defn- resolve-value
   "Convert a filter value into the Pinot-ready representation. Delegates to `->rvalue` so we correctly handle
@@ -113,7 +187,7 @@
 (defmethod ->rvalue :field
   [[_ id-or-name]]
   (if (integer? id-or-name)
-    (:name (lib.metadata/field (qp.store/metadata-provider) id-or-name))
+    (:name (field-metadata id-or-name))
     id-or-name))
 
 (defmethod ->rvalue :absolute-datetime
@@ -257,10 +331,12 @@
   [original-query pinot-query]
   ;; Extract breakout fields from the original query and add to pinot-query
   (let [breakout (:breakout original-query)
-        breakout-names (map resolve-field breakout)]
+        breakout-names (map resolve-field breakout)
+        breakout-selects (map resolve-select-field breakout)]
     (if (seq breakout-names)
       (-> pinot-query
-                (assoc-in [:query :group-by] breakout-names))
+                (assoc-in [:query :group-by] breakout-names)
+                (assoc-in [:query :breakout-selects] breakout-selects))
             pinot-query)))
 
 ;;; ------------------------------------------------ handle-order-by -------------------------------------------------
@@ -282,7 +358,7 @@
   [original-query pinot-query]
   ;; Extract fields from the original query and add to pinot-query
   (let [fields (:fields original-query)
-        field-names (map resolve-field fields)]
+        field-names (map resolve-select-field fields)]
     (if (seq field-names)
       (assoc-in pinot-query [:query :columns] field-names)
       (assoc-in pinot-query [:query :columns] []))))
@@ -316,8 +392,10 @@
   ;; Generate the SQL string for Pinot from the pinot-query map
   (let [
         group-by-exists? (get-in pinot-query [:query :group-by])
+        breakout-selects (or (get-in pinot-query [:query :breakout-selects])
+                             (get-in pinot-query [:query :group-by]))
         select-clause (if group-by-exists?
-                        (str "SELECT " (str/join ", " (concat (get-in pinot-query [:query :group-by]) (get-in pinot-query [:query :aggregations]))))
+                        (str "SELECT " (str/join ", " (concat breakout-selects (get-in pinot-query [:query :aggregations]))))
                         (if (get-in pinot-query [:query :aggregations])
                           (str "SELECT " (str/join ", " (get-in pinot-query [:query :aggregations])))
                           (str "SELECT " (str/join ", " (get-in pinot-query [:query :columns])))))

--- a/drivers/pinot/test/metabase/driver/pinot/query_processor_test.clj
+++ b/drivers/pinot/test/metabase/driver/pinot/query_processor_test.clj
@@ -23,7 +23,9 @@
 (def metadata-provider
   {:tables {1 {:id 1 :name "events"}}
    :fields {1 {:id 1 :name "id"}
-            2 {:id 2 :name "price"}}})
+            2 {:id 2 :name "price"}
+            3 {:id 3 :name "created_at" :database-type "TIMESTAMP" :format "1:MILLISECONDS:EPOCH"}
+            4 {:id 4 :name "order_day" :database-type "INT" :format "1:DAYS:EPOCH"}}})
 
 (def redefine-metadata!
   {:qp.store/metadata-provider (constantly metadata-provider)
@@ -179,6 +181,53 @@
     (is (= "\"dropdown_column\"" (#'qp/resolve-field [:field "dropdown_column" nil])))
     ;; options map is used when field-id is not integer/string (e.g. keyword)
     (is (= "\"from_options\"" (#'qp/resolve-field [:field :id {:name "from_options"}])))))
+
+(deftest temporal-breakout-uses-pinot-datetrunc
+  (with-redefs [qp.store/metadata-provider (:qp.store/metadata-provider redefine-metadata!)
+                lib.metadata/table (:lib.metadata/table redefine-metadata!)
+                lib.metadata/field (:lib.metadata/field redefine-metadata!)]
+    (let [query {:database 1
+                 :type :query
+                 :settings {:timezone "America/Los_Angeles"}
+                 :query {:source-table 1
+                         :breakout [[:field 3 {:temporal-unit :day}]]
+                         :aggregation [[:aggregation [:count] {:name "total"}]]
+                         :order-by [[:asc [:field 3 {:temporal-unit :day}]]]
+                         :limit 10}}
+          result (qp/mbql->native query)
+          day-expression "DATETRUNC('day', \"created_at\", 'MILLISECONDS', 'America/Los_Angeles', 'MILLISECONDS')"
+          sql (get-in result [:query :sql])]
+      (is (= [day-expression] (get-in result [:query :group-by])))
+      (is (= [(str day-expression " AS \"created_at__day\"")]
+             (get-in result [:query :breakout-selects])))
+      (is (= [(str day-expression " asc")] (get-in result [:query :order-by])))
+      (is (= (str "SELECT " day-expression " AS \"created_at__day\", COUNT(*) AS total "
+                  "FROM events GROUP BY " day-expression " ORDER BY " day-expression " asc LIMIT 10")
+             sql)))))
+
+(deftest temporal-field-select-uses-schema-input-time-unit
+  (with-redefs [qp.store/metadata-provider (:qp.store/metadata-provider redefine-metadata!)
+                lib.metadata/table (:lib.metadata/table redefine-metadata!)
+                lib.metadata/field (:lib.metadata/field redefine-metadata!)]
+    (let [query {:database 1
+                 :type :query
+                 :settings {:timezone "UTC"}
+                 :query {:source-table 1
+                         :fields [[:field 4 {:temporal-unit :month}]]
+                         :limit 5}}
+          result (qp/mbql->native query)
+          month-expression "DATETRUNC('month', \"order_day\", 'DAYS', 'UTC', 'MILLISECONDS')"]
+      (is (= [(str month-expression " AS \"order_day__month\"")]
+             (get-in result [:query :columns])))
+      (is (= (str "SELECT " month-expression " AS \"order_day__month\" FROM events LIMIT 5")
+             (get-in result [:query :sql]))))))
+
+(deftest temporal-default-unit-keeps-raw-field
+  (with-redefs [qp.store/metadata-provider (:qp.store/metadata-provider redefine-metadata!)
+                lib.metadata/table (:lib.metadata/table redefine-metadata!)
+                lib.metadata/field (:lib.metadata/field redefine-metadata!)]
+    (is (= "\"created_at\""
+           (#'qp/resolve-field [:field 3 {:temporal-unit :default}])))))
 
 (deftest resolve-field-else-unknown-type
   (with-redefs [qp.store/metadata-provider (:qp.store/metadata-provider redefine-metadata!)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ Starts a local Apache Pinot cluster with sample data for testing.
 - Starts a multi-stage quickstart cluster
 - Includes sample datasets: airlineStats, baseballStats, dimBaseballTeams, githubComplexTypeEvents, githubEvents, starbucksStores
 - Waits for cluster to be ready and validates data availability
+- Validates a `DATETRUNC` time-grain query that matches Metabase temporal grouping SQL
 - Configurable via environment variables
 
 **Usage:**
@@ -55,18 +56,29 @@ After starting the cluster, you can test with these sample queries:
 SELECT COUNT(*) FROM baseballStats
 
 -- Get airline stats by carrier
-SELECT Carrier, COUNT(*) as flights 
-FROM airlineStats 
-GROUP BY Carrier 
-ORDER BY flights DESC 
+SELECT Carrier, COUNT(*) as flights
+FROM airlineStats
+GROUP BY Carrier
+ORDER BY flights DESC
 LIMIT 10
 
 -- GitHub events by type
-SELECT type, COUNT(*) as event_count 
-FROM githubEvents 
-GROUP BY type 
+SELECT type, COUNT(*) as event_count
+FROM githubEvents
+GROUP BY type
 ORDER BY event_count DESC
+
+-- Metabase time-grain grouping shape for Pinot date columns
+SELECT
+  DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS') AS "DaysSinceEpoch__day",
+  COUNT(*) AS "flights"
+FROM airlineStats
+GROUP BY DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS')
+ORDER BY DATETRUNC('day', "DaysSinceEpoch", 'DAYS', 'UTC', 'MILLISECONDS') ASC
+LIMIT 5
 ```
+
+The start script runs the `DATETRUNC` query above as an e2e guard for Metabase time-grain grouping. It fails the quickstart if Pinot returns exceptions, no bucket rows, a nonnumeric bucket, or a nonpositive count.
 
 ## Requirements
 
@@ -79,4 +91,4 @@ ORDER BY event_count DESC
 - The start script will automatically download Apache Pinot if not already present
 - The cluster includes sample data that's perfect for testing the Metabase Pinot driver
 - Scripts are based on the [startreedata/pinot-client-go](https://github.com/startreedata/pinot-client-go) repository
-- For production use, consider using proper Pinot deployment methods instead of these quickstart scripts 
+- For production use, consider using proper Pinot deployment methods instead of these quickstart scripts

--- a/scripts/start-pinot-quickstart.sh
+++ b/scripts/start-pinot-quickstart.sh
@@ -46,6 +46,18 @@ PID=$!
 # Print the JVM settings
 jps -lvm
 
+run_sql() {
+  local sql="$1"
+  local payload
+
+  payload=$(jq -n --arg sql "${sql}" '{sql: $sql}')
+  curl -s -X POST \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d "${payload}" \
+    "http://localhost:${BROKER_PORT_FORWARD}/query/sql"
+}
+
 ### ---------------------------------------------------------------------------
 ### Ensure Pinot cluster started correctly.
 ### ---------------------------------------------------------------------------
@@ -59,13 +71,13 @@ do
   for table in "airlineStats" "baseballStats" "dimBaseballTeams" "githubComplexTypeEvents" "githubEvents" "starbucksStores";
   do
     QUERY="select count(*) from ${table} limit 1"
-    QUERY_REQUEST='curl -s -X POST -H '"'"'Accept: application/json'"'"' -d '"'"'{"sql": "'${QUERY}'"}'"'"' http://localhost:'${BROKER_PORT_FORWARD}'/query/sql'
-    echo ${QUERY_REQUEST}
-    QUERY_RES=`eval ${QUERY_REQUEST}`
-    echo ${QUERY_RES}
+    echo "Running SQL: ${QUERY}"
+    QUERY_RES=$(run_sql "${QUERY}")
+    QUERY_STATUS=$?
+    echo "${QUERY_RES}"
 
-    if [ $? -eq 0 ]; then
-      COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
+    if [ "${QUERY_STATUS}" -eq 0 ]; then
+      COUNT_STAR_RES=$(echo "${QUERY_RES}" | jq -r '.resultTable.rows[0][0] // 0')
       if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -gt 0 ]; then
         SUCCEED_TABLE=$((SUCCEED_TABLE+1))
       fi
@@ -83,4 +95,42 @@ if [ "${SUCCEED_TABLE}" -lt 6 ]; then
   echo 'Quickstart failed: Cannot confirmed count-star result from quickstart table in 10 minutes'
   exit 1
 fi
-echo "Pinot cluster started correctly" 
+
+### ---------------------------------------------------------------------------
+### Validate Metabase temporal grouping query shape.
+### ---------------------------------------------------------------------------
+
+TEMPORAL_DAY_EXPRESSION="DATETRUNC('day', \"DaysSinceEpoch\", 'DAYS', 'UTC', 'MILLISECONDS')"
+TEMPORAL_QUERY="SELECT ${TEMPORAL_DAY_EXPRESSION} AS \"DaysSinceEpoch__day\", COUNT(*) AS \"flights\" FROM airlineStats GROUP BY ${TEMPORAL_DAY_EXPRESSION} ORDER BY ${TEMPORAL_DAY_EXPRESSION} ASC LIMIT 5"
+
+echo "Validating temporal bucket query used by Metabase time-grain grouping"
+echo "Running SQL: ${TEMPORAL_QUERY}"
+TEMPORAL_RES=$(run_sql "${TEMPORAL_QUERY}")
+TEMPORAL_STATUS=$?
+echo "${TEMPORAL_RES}"
+
+if [ "${TEMPORAL_STATUS}" -ne 0 ]; then
+  echo "Quickstart failed: temporal bucket query request failed"
+  exit 1
+fi
+
+TEMPORAL_EXCEPTION_COUNT=$(echo "${TEMPORAL_RES}" | jq -r '(.exceptions // []) | length' 2>/dev/null || echo 1)
+TEMPORAL_ROW_COUNT=$(echo "${TEMPORAL_RES}" | jq -r '(.resultTable.rows // []) | length' 2>/dev/null || echo 0)
+TEMPORAL_FIRST_BUCKET=$(echo "${TEMPORAL_RES}" | jq -r '.resultTable.rows[0][0] // empty' 2>/dev/null || true)
+TEMPORAL_FIRST_COUNT=$(echo "${TEMPORAL_RES}" | jq -r '.resultTable.rows[0][1] // 0' 2>/dev/null || echo 0)
+
+if [ "${TEMPORAL_EXCEPTION_COUNT}" -gt 0 ]; then
+  echo "Quickstart failed: temporal bucket query returned Pinot exceptions"
+  exit 1
+fi
+
+if [ "${TEMPORAL_ROW_COUNT}" -lt 1 ] ||
+   ! [[ "${TEMPORAL_FIRST_BUCKET}" =~ ^[0-9]+$ ]] ||
+   ! [[ "${TEMPORAL_FIRST_COUNT}" =~ ^[0-9]+$ ]] ||
+   [ "${TEMPORAL_FIRST_COUNT}" -lt 1 ]; then
+  echo "Quickstart failed: temporal bucket query did not return valid bucketed rows"
+  exit 1
+fi
+
+echo "Temporal bucket query validated correctly"
+echo "Pinot cluster started correctly"


### PR DESCRIPTION
## Summary
- translate Metabase temporal field breakouts to Pinot DATETRUNC expressions with timezone and schema-derived input units
- alias temporal projections as `<field>__<grain>` so Pinot does not confuse a SELECT alias with the grouped source column
- add quickstart DATETRUNC validation plus user-facing configuration docs, sample dateTimeFieldSpecs, and sample queries

## Validation
- `bash -n scripts/start-pinot-quickstart.sh scripts/stop-pinot-quickstart.sh scripts/release.sh`
- `git diff --check`
- local Pinot e2e DATETRUNC query against `airlineStats` returned bucket rows with alias `DaysSinceEpoch__day`
- `clojure -M:clj-kondo`
- `clojure -M:test -e "(require 'clojure.test 'metabase.driver.pinot.query-processor-test) ..."` (41 tests, 94 assertions)
- `clojure -M:test-runner --config-file tests.edn --reporter kaocha.report/documentation` (252 tests, 663 assertions)
- `clojure -X:test-coverage` (70.34% form coverage, threshold 68%)