### PR TITLE
[codex] Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Start Pinot
       run: |
@@ -27,18 +27,18 @@ jobs:
         ./scripts/start-pinot-quickstart.sh
 
     - name: Set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.6.1
       with:
         cli: 1.12.1.1550
 
     - name: Cache Clojure dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2
@@ -59,7 +59,7 @@ jobs:
         fi
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -115,7 +115,7 @@ jobs:
         echo "=== Test execution completed ==="
 
     - name: Upload test results and coverage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results-and-coverage
@@ -139,7 +139,7 @@ jobs:
         verbose: true
 
     - name: Comment coverage report
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       if: github.event_name == 'pull_request' && always()
       with:
         script: |
@@ -198,15 +198,15 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.6.1
       with:
         cli: 1.12.1.1550
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2
@@ -227,21 +227,21 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
     
     - name: Set up Clojure CLI
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.6.1
       with:
         cli: 1.12.1.1550
     
     - name: Cache Clojure dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2
@@ -261,7 +261,7 @@ jobs:
         fi
     
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -329,15 +329,15 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.6.1
       with:
         cli: 1.12.1.1550
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -34,7 +34,7 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.commit_sha }}
         fetch-depth: 0
@@ -53,18 +53,18 @@ jobs:
         echo "✅ All inputs validated successfully"
 
     - name: Set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@13.4
+      uses: DeLaGuardo/setup-clojure@13.6.1
       with:
         cli: 1.12.1.1550
 
     - name: Cache Clojure dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2
@@ -85,7 +85,7 @@ jobs:
         fi
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -176,7 +176,7 @@ jobs:
         ls -la
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ inputs.version }}
         name: Pinot Driver v${{ inputs.version }}
@@ -200,4 +200,4 @@ jobs:
         echo "📦 Artifacts:"
         echo "   - pinot.metabase-driver-v${{ inputs.version }}.jar"
         echo "   - pinot.metabase-driver-v${{ inputs.version }}.jar.sha256"
-        echo "🌐 Release URL: https://github.com/${{ github.repository }}/releases/tag/v${{ inputs.version }}" 
+        echo "🌐 Release URL: https://github.com/${{ github.repository }}/releases/tag/v${{ inputs.version }}"


### PR DESCRIPTION
## Summary
- Bump GitHub Actions workflow dependencies to Node 24-compatible action versions.
- Update CI, GitHub Pages, and release workflows so they no longer depend on deprecated Node.js 20 JavaScript action runtimes.
- Include the Pages deploy action update as well, since `actions/deploy-pages@v4` still declares `node20`.

## Root cause
GitHub Actions is deprecating Node.js 20 for JavaScript actions. The current workflows referenced action versions that run on Node.js 20 and will start warning or failing as GitHub changes the runner defaults.

## User manual
No application user action is required. Maintainers can run the CI, Pages, and release workflows normally; the workflows now resolve to action versions that declare Node.js 24 where applicable.

## Sample table config or queries
Not applicable. This PR only updates GitHub Actions workflow action versions and does not change Pinot driver behavior or query/table configuration.

## Validation
- `gh api` checks confirmed the new action tags exist upstream.
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/pages.yml .github/workflows/release.yml`
- `git diff --check HEAD^..HEAD`
- Searched workflows to confirm the old Node 20-triggering action refs are gone.

`actionlint` was not installed locally, so that lint pass was not run.
